### PR TITLE
Use hex instead of octal literal for strict mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -186,7 +186,7 @@ function aha(input, options) {
     // read input one byte at a time (interpreted as an ASCII character code)
     while (!eof()) {
         c = getNextChar();
-        if (c === '\033') {
+        if (c === "\x1b") {
             // save old values
             ofc = fc;
             obc = bc;


### PR DESCRIPTION
This is needed when running ES6 in strict mode.